### PR TITLE
Enhancement/issue#66

### DIFF
--- a/back/src/controller/bucketController.ts
+++ b/back/src/controller/bucketController.ts
@@ -14,6 +14,7 @@ const bucketController = {
           Key: key,
           Expires: 60,
           ContentType: type,
+          ACL: 'public-read',
         });
         return { presignedURL, key };
       }),

--- a/cloud-functions/index.js
+++ b/cloud-functions/index.js
@@ -1,9 +1,6 @@
 const sharp = require('sharp');
 const aws = require('aws-sdk');
-const sizes = [
-  { width: 120, height: 120 },
-  { width: 143, height: 160 },
-];
+const sizes = [{ width: 120, height: 120 }];
 const credentials = new aws.Credentials({
   accessKeyId: process.env.NCP_ACCESS_KEY_ID,
   secretAccessKey: process.env.NCP_SECRET_ACCESS_KEY,

--- a/front/src/components/ImgPreView/index.tsx
+++ b/front/src/components/ImgPreView/index.tsx
@@ -5,25 +5,32 @@ import { ImgInfo } from '../../types/Datas';
 
 interface Props {
   info: ImgInfo;
+  tab: 1 | 2;
 }
 
-function ImgPreView({ info }: Props): JSX.Element {
+function ImgPreView({ info, tab }: Props): JSX.Element {
+  const imgURLEndPoint = 'https://kr.object.ncloudstorage.com';
+  const resizedImgURL = `${imgURLEndPoint}/image-w120h120/${info.key}.webp`;
+  const originImgURL = `${imgURLEndPoint}/wiziboost-image-raw/${info.key}`;
+  const initialImgURL = tab === 1 ? originImgURL : resizedImgURL;
   const [isLoading, setIsLoading] = useState(true);
-  const imgURL = `https://kr.object.ncloudstorage.com/wiziboost-image-raw/${info.key}`;
+  const [imgURL, setImgURL] = useState(initialImgURL);
+  const placeholder = <Loading type="spin" color="black" />;
+  const onError = () => setImgURL(originImgURL);
 
   return (
-    <Container isLoading={isLoading}>
-      {isLoading && <Loading type="spin" color="black" />}
+    <Container isLoading={isLoading} tab={tab}>
+      {isLoading && placeholder}
       {info.isUploaded && (
-        <Img src={imgURL} onLoad={() => setIsLoading(false)} alt="" isLoading={isLoading} width={143} height={160} />
+        <Img src={imgURL} onLoad={() => setIsLoading(false)} onError={onError} alt="" isLoading={isLoading} tab={tab} />
       )}
     </Container>
   );
 }
 
-const Container = styled.li<{ isLoading: boolean }>`
-  width: 143px;
-  height: 160px;
+const Container = styled.li<{ isLoading: boolean; tab: number }>`
+  width: ${({ tab }) => (tab === 1 ? '143px' : '120px')};
+  height: ${({ tab }) => (tab === 1 ? '160px' : '120px')};
   position: relative;
   border-radius: 13px;
   border: ${({ isLoading }) => (isLoading ? `1px solid black` : `none`)};
@@ -35,9 +42,11 @@ const Container = styled.li<{ isLoading: boolean }>`
   }
 `;
 
-const Img = styled.img<{ isLoading: boolean }>`
+const Img = styled.img<{ isLoading: boolean; tab: number }>`
   border-radius: 13px;
   visibility: ${({ isLoading }) => (isLoading ? 'hidden' : 'visible')};
+  width: ${({ tab }) => (tab === 1 ? '143px' : '120px')};
+  height: ${({ tab }) => (tab === 1 ? '160px' : '120px')};
 `;
 
 export default ImgPreView;

--- a/front/src/components/ImgPreView/index.tsx
+++ b/front/src/components/ImgPreView/index.tsx
@@ -1,44 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { MdCancel } from 'react-icons/md';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import Loading from 'react-loading';
 import { ImgInfo } from '../../types/Datas';
 
 interface Props {
-  onDelete: (key: string) => void;
   info: ImgInfo;
-  deleteBtnExist: boolean;
-  width: 143 | 120;
-  height: 160 | 120;
 }
 
-function ImgPreView({ onDelete, info, width, height, deleteBtnExist }: Props): JSX.Element {
+function ImgPreView({ info }: Props): JSX.Element {
   const [isLoading, setIsLoading] = useState(true);
   const imgURL = `https://kr.object.ncloudstorage.com/wiziboost-image-raw/${info.key}`;
 
   return (
-    <Container isLoading={isLoading} style={{ width, height }}>
+    <Container isLoading={isLoading}>
       {isLoading && <Loading type="spin" color="black" />}
-      {!isLoading && deleteBtnExist && (
-        <Btn type="button" onClick={() => onDelete(info.key)}>
-          <MdCancel size={40} color="red" />
-        </Btn>
-      )}
       {info.isUploaded && (
-        <Img
-          src={imgURL}
-          onLoad={() => setIsLoading(false)}
-          alt=""
-          isLoading={isLoading}
-          width={width}
-          height={height}
-        />
+        <Img src={imgURL} onLoad={() => setIsLoading(false)} alt="" isLoading={isLoading} width={143} height={160} />
       )}
     </Container>
   );
 }
 
 const Container = styled.li<{ isLoading: boolean }>`
+  width: 143px;
+  height: 160px;
   position: relative;
   border-radius: 13px;
   border: ${({ isLoading }) => (isLoading ? `1px solid black` : `none`)};
@@ -50,18 +35,9 @@ const Container = styled.li<{ isLoading: boolean }>`
   }
 `;
 
-const Btn = styled.button`
-  position: absolute;
-  background-color: ${({ theme }) => theme.color.white};
-  border-radius: 50%;
-  height: 40px;
-  right: -20px;
-  top: -20px;
-`;
-
 const Img = styled.img<{ isLoading: boolean }>`
   border-radius: 13px;
-  display: ${({ isLoading }) => (isLoading ? `none` : `inline`)};
+  visibility: ${({ isLoading }) => (isLoading ? 'hidden' : 'visible')};
 `;
 
 export default ImgPreView;

--- a/front/src/components/ImgPreView/index.tsx
+++ b/front/src/components/ImgPreView/index.tsx
@@ -14,22 +14,7 @@ interface Props {
 
 function ImgPreView({ onDelete, info, width, height, deleteBtnExist }: Props): JSX.Element {
   const [isLoading, setIsLoading] = useState(true);
-  const [imgURL, setImgURL] = useState(
-    `https://kr.object.ncloudstorage.com/image-w${width}h${height}/${info.key}.webp#${Date.now()}`,
-  );
-
-  useEffect(() => {
-    const { key } = info;
-    const intervalId = setInterval(() => {
-      if (!isLoading) {
-        clearInterval(intervalId);
-        return;
-      }
-      const newImgURL = `https://kr.object.ncloudstorage.com/image-w${width}h${height}/${key}.webp#${Date.now()}`;
-      setImgURL(newImgURL);
-    }, 1000);
-    return () => clearInterval(intervalId);
-  }, [isLoading]);
+  const imgURL = `https://kr.object.ncloudstorage.com/wiziboost-image-raw/${info.key}`;
 
   return (
     <Container isLoading={isLoading} style={{ width, height }}>
@@ -39,7 +24,16 @@ function ImgPreView({ onDelete, info, width, height, deleteBtnExist }: Props): J
           <MdCancel size={40} color="red" />
         </Btn>
       )}
-      <Img src={imgURL} onLoad={() => setIsLoading(false)} alt="" isLoading={isLoading} width={width} height={height} />
+      {info.isUploaded && (
+        <Img
+          src={imgURL}
+          onLoad={() => setIsLoading(false)}
+          alt=""
+          isLoading={isLoading}
+          width={width}
+          height={height}
+        />
+      )}
     </Container>
   );
 }

--- a/front/src/components/ImgPreViewList/index.tsx
+++ b/front/src/components/ImgPreViewList/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 function ImgPreViewList({ onChange, onDeleteImg, imgInfos }: Props): JSX.Element {
   const imgListRef = useRef<HTMLUListElement | null>(null);
-  const imgs = imgInfos.map((info: ImgInfo) => <ImgPreView key={info.key} info={info} />);
+  const imgs = imgInfos.map((info: ImgInfo) => <ImgPreView key={info.key} info={info} tab={1} />);
   return (
     <Container>
       <ImgInput onChange={onChange} type="addAdditionalImgs" />

--- a/front/src/components/ImgPreViewList/index.tsx
+++ b/front/src/components/ImgPreViewList/index.tsx
@@ -12,9 +12,7 @@ interface Props {
 
 function ImgPreViewList({ onChange, onDeleteImg, imgInfos }: Props): JSX.Element {
   const imgListRef = useRef<HTMLUListElement | null>(null);
-  const imgs = imgInfos.map((info: ImgInfo) => (
-    <ImgPreView key={info.key} onDelete={onDeleteImg} info={info} width={143} height={160} deleteBtnExist />
-  ));
+  const imgs = imgInfos.map((info: ImgInfo) => <ImgPreView key={info.key} info={info} />);
   return (
     <Container>
       <ImgInput onChange={onChange} type="addAdditionalImgs" />

--- a/front/src/components/ImgTableRow/index.tsx
+++ b/front/src/components/ImgTableRow/index.tsx
@@ -18,7 +18,7 @@ function ImgTableRow({ imgInfo, num, onDelete, getOnImgNameChange, getOnImgChang
     <Container>
       <RowItem style={{ width: '138px' }}>{num}</RowItem>
       <RowItem style={{ width: '144px' }}>
-        <ImgPreView onDelete={onDelete} info={imgInfo} width={120} height={120} deleteBtnExist={false} />
+        <ImgPreView info={imgInfo} tab={2} />
       </RowItem>
       <RowItem style={{ width: '487px' }}>
         <TextInput

--- a/front/src/pages/Make/index.tsx
+++ b/front/src/pages/Make/index.tsx
@@ -36,7 +36,7 @@ function Make(): JSX.Element {
       const fileReader = new FileReader();
       fileReader.addEventListener('load', ({ target }) => {
         if (!target || !target.result || typeof target.result === 'string') return;
-        axios.put(presignedURL, target.result, { headers: { 'Content-Type': file.type } });
+        axios.put(presignedURL, target.result, { headers: { 'Content-Type': file.type, 'x-amz-acl': 'public-read' } });
       });
       fileReader.readAsArrayBuffer(file);
       return { name: file.name, key };

--- a/front/src/pages/Make/index.tsx
+++ b/front/src/pages/Make/index.tsx
@@ -87,6 +87,7 @@ function Make(): JSX.Element {
     return () => {
       if (currentTab === tabNum) return;
       setCurrentTab(tabNum);
+      previewStartIdx.current = imgInfos.length;
     };
   };
 
@@ -108,11 +109,6 @@ function Make(): JSX.Element {
       });
     };
   };
-
-  useEffect(() => {
-    if (currentTab !== 1) return;
-    previewStartIdx.current = imgInfos.length;
-  }, [currentTab]);
 
   return (
     <>

--- a/front/src/pages/Make/index.tsx
+++ b/front/src/pages/Make/index.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useState, useEffect } from 'react';
+import React, { useReducer, useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
 import { Header, MakeWorldcupForm, ImgTable, MakePageTabBar } from '../../components';
@@ -10,16 +10,17 @@ function Make(): JSX.Element {
   const [currentPage, setCurrentPage] = useState(1);
   const [preViews, setPreViews] = useState<ImgInfo[]>([]);
   const [worldcupFormState, worldcupFormDispatcher] = useReducer(worldcupFormReducer, initialWorldcupFormState);
+  const previewStartIdx = useRef(0);
   const { title, desc, keywords, imgInfos } = worldcupFormState;
 
   const onTitleChange: React.ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    worldcupFormDispatcher({ type: 'title', payload: target.value });
+    worldcupFormDispatcher({ type: 'CHANGE_TITLE', payload: target.value });
   };
   const onDescChange: React.ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    worldcupFormDispatcher({ type: 'desc', payload: target.value });
+    worldcupFormDispatcher({ type: 'CHANGE_DESC', payload: target.value });
   };
   const onKeywordsChange: React.ChangeEventHandler<HTMLInputElement> = ({ target }) => {
-    worldcupFormDispatcher({ type: 'keywords', payload: [target.value] });
+    worldcupFormDispatcher({ type: 'ADD_KEYWORD', payload: target.value });
   };
 
   const onAddImgs: React.ChangeEventHandler<HTMLInputElement> = async ({ target }) => {
@@ -34,22 +35,24 @@ function Make(): JSX.Element {
       const { presignedURL, key } = presignedData;
       const file = newFiles[idx];
       const fileReader = new FileReader();
-      fileReader.addEventListener('load', ({ target }) => {
+      fileReader.addEventListener('load', async ({ target }) => {
         if (!target || !target.result || typeof target.result === 'string') return;
-        axios.put(presignedURL, target.result, { headers: { 'Content-Type': file.type, 'x-amz-acl': 'public-read' } });
+        await axios.put(presignedURL, target.result, {
+          headers: { 'Content-Type': file.type, 'x-amz-acl': 'public-read' },
+        });
+        worldcupFormDispatcher({ type: 'FINISH_IMG_UPLOAD', payload: key });
       });
       fileReader.readAsArrayBuffer(file);
-      return { name: file.name, key };
+      return { name: file.name, isUploaded: false, key };
     });
-    worldcupFormDispatcher({ type: 'imgInfos', payload: [...imgInfos, ...newImgInfos] });
+    worldcupFormDispatcher({ type: 'ADD_IMGS', payload: newImgInfos });
     setPreViews([...preViews, ...newImgInfos]);
   };
 
   const onDeleteImg = (imgKey: string) => {
-    const targetIdx = imgInfos.findIndex((info: ImgInfo) => info.key === imgKey);
     worldcupFormDispatcher({
-      type: 'imgInfos',
-      payload: [...imgInfos.slice(0, targetIdx), ...imgInfos.slice(targetIdx + 1)],
+      type: 'DELETE_IMG',
+      payload: imgKey,
     });
 
     const targetIdxInPriViews = preViews.findIndex((info: ImgInfo) => info.key === imgKey);
@@ -59,7 +62,7 @@ function Make(): JSX.Element {
     axios.delete(`/api/candidates/${imgKey}`);
   };
 
-  const getOnImgChange = (preImgKey: string) => {
+  const getOnImgChange = (preKey: string) => {
     return async (e: React.ChangeEvent<HTMLInputElement>) => {
       if (!e.target.files) return;
       const [file] = [...e.target.files];
@@ -67,15 +70,15 @@ function Make(): JSX.Element {
       const { data } = await axios.post('/api/bucket/url', { contentTypes });
       const { key, presignedURL } = data[0];
       const fileReader = new FileReader();
-      fileReader.addEventListener('load', ({ target }) => {
+      fileReader.addEventListener('load', async ({ target }) => {
         if (!target || !target.result || typeof target.result === 'string') return;
-        axios.put(presignedURL, target.result, { headers: { 'Content-Type': file.type } });
+        await axios.put(presignedURL, target.result, { headers: { 'Content-Type': file.type } });
+        worldcupFormDispatcher({ type: 'FINISH_IMG_UPLOAD', payload: key });
       });
       fileReader.readAsArrayBuffer(file);
-      const targetIdx = imgInfos.findIndex((info: ImgInfo) => info.key === preImgKey);
       worldcupFormDispatcher({
-        type: 'imgInfos',
-        payload: [...imgInfos.slice(0, targetIdx), { key, name: file.name }, ...imgInfos.slice(targetIdx + 1)],
+        type: 'CHANGE_IMG',
+        payload: { newKey: key, name: file.name, preKey },
       });
     };
   };
@@ -97,22 +100,18 @@ function Make(): JSX.Element {
     });
   };
 
-  const getOnImgNameChange = (imgKey: string) => {
+  const getOnImgNameChange = (key: string) => {
     return (e: React.ChangeEvent<HTMLInputElement>) => {
-      const targetIdx = imgInfos.findIndex((info) => info.key === imgKey);
       worldcupFormDispatcher({
-        type: 'imgInfos',
-        payload: [
-          ...imgInfos.slice(0, targetIdx),
-          { ...imgInfos[targetIdx], name: e.target.value },
-          ...imgInfos.slice(targetIdx + 1),
-        ],
+        type: 'CHANGE_IMG_NAME',
+        payload: { key, name: e.target.value },
       });
     };
   };
 
   useEffect(() => {
-    setPreViews([]);
+    if (currentTab !== 1) return;
+    previewStartIdx.current = imgInfos.length;
   }, [currentTab]);
 
   return (
@@ -128,7 +127,7 @@ function Make(): JSX.Element {
             onAddImgs={onAddImgs}
             onDeleteImg={onDeleteImg}
             onStore={onStore}
-            imgInfos={preViews}
+            imgInfos={imgInfos.slice(previewStartIdx.current)}
           />
         )}
         {currentTab === 2 && (

--- a/front/src/pages/Make/reducer.ts
+++ b/front/src/pages/Make/reducer.ts
@@ -1,5 +1,21 @@
-import { WorldcupFormState } from '../../types/States';
-import { FormAction } from '../../types/Actions';
+import { ImgInfo } from '../../types/Datas';
+
+export interface WorldcupFormState {
+  title: string;
+  desc: string;
+  keywords: string[];
+  imgInfos: ImgInfo[];
+}
+
+export type WorldcupFormAction =
+  | { type: 'CHANGE_TITLE'; payload: string }
+  | { type: 'CHANGE_DESC'; payload: string }
+  | { type: 'CHANGE_IMG'; payload: { preKey: string; newKey: string; name: string } }
+  | { type: 'CHANGE_IMG_NAME'; payload: { key: string; name: string } }
+  | { type: 'ADD_KEYWORD'; payload: string }
+  | { type: 'ADD_IMGS'; payload: ImgInfo[] }
+  | { type: 'DELETE_IMG'; payload: string }
+  | { type: 'FINISH_IMG_UPLOAD'; payload: string };
 
 export const initialWorldcupFormState: WorldcupFormState = {
   title: '',
@@ -8,7 +24,75 @@ export const initialWorldcupFormState: WorldcupFormState = {
   imgInfos: [],
 };
 
-export default (state: WorldcupFormState, action: FormAction<WorldcupFormState>): WorldcupFormState => {
-  const { type, payload } = action;
-  return { ...state, [type]: payload };
+export default (state: WorldcupFormState, action: WorldcupFormAction): WorldcupFormState => {
+  switch (action.type) {
+    case 'CHANGE_TITLE': {
+      const { payload: newTitle } = action;
+      return { ...state, title: newTitle };
+    }
+
+    case 'CHANGE_DESC': {
+      const { payload: newDesc } = action;
+      return { ...state, desc: newDesc };
+    }
+
+    case 'CHANGE_IMG': {
+      const { preKey, newKey, name: newName } = action.payload;
+      const { imgInfos: preImgInfos } = state;
+      const targetIdx = preImgInfos.findIndex((info) => info.key === preKey);
+      const newImgInfos = [
+        ...preImgInfos.slice(0, targetIdx),
+        { key: newKey, name: newName, isUploaded: false },
+        ...preImgInfos.slice(targetIdx + 1),
+      ];
+      return { ...state, imgInfos: newImgInfos };
+    }
+
+    case 'CHANGE_IMG_NAME': {
+      const { key, name: newName } = action.payload;
+      const { imgInfos: preImgInfos } = state;
+      const targetIdx = preImgInfos.findIndex((info) => info.key === key);
+      const newImgInfos = [
+        ...preImgInfos.slice(0, targetIdx),
+        { ...preImgInfos[targetIdx], name: newName },
+        ...preImgInfos.slice(targetIdx + 1),
+      ];
+      return { ...state, imgInfos: newImgInfos };
+    }
+
+    case 'ADD_KEYWORD': {
+      const { payload: newKeyword } = action;
+      return { ...state, keywords: [newKeyword] };
+    }
+
+    case 'ADD_IMGS': {
+      const { payload: newImgInfos } = action;
+      const { imgInfos: preImgInfos } = state;
+      return { ...state, imgInfos: [...preImgInfos, ...newImgInfos] };
+    }
+
+    case 'DELETE_IMG': {
+      const { payload: key } = action;
+      const { imgInfos: preImgInfos } = state;
+      const targetIdx = preImgInfos.findIndex((info) => info.key === key);
+      const newImgInfos = [...preImgInfos.slice(0, targetIdx), ...preImgInfos.slice(targetIdx + 1)];
+      return { ...state, imgInfos: newImgInfos };
+    }
+
+    case 'FINISH_IMG_UPLOAD': {
+      const { payload: key } = action;
+      const { imgInfos: preImgInfos } = state;
+      const targetIdx = preImgInfos.findIndex((info) => info.key === key);
+      const newImgInfos = [
+        ...preImgInfos.slice(0, targetIdx),
+        { ...preImgInfos[targetIdx], isUploaded: true },
+        ...preImgInfos.slice(targetIdx + 1),
+      ];
+      return { ...state, imgInfos: newImgInfos };
+    }
+
+    default: {
+      throw new Error('Unexpected action type');
+    }
+  }
 };

--- a/front/src/types/Datas.ts
+++ b/front/src/types/Datas.ts
@@ -6,6 +6,7 @@ export interface PreSignedData {
 export interface ImgInfo {
   key: string;
   name: string;
+  isUploaded: boolean;
 }
 
 export interface candidateData {


### PR DESCRIPTION
- 원본 사진도 public-read하게 저장되도록 변경하였습니다.
- make 페이지 첫 번째 탭의 미리보기는 항상 원본 사진만을 보여주도록 했습니다.
- 두 번째 탭의 미리보기는 마운트 될 때 리사이징 사진에 요청을 보낸 뒤, 실패하면 원본 사진을 보여주도록 했습니다.
