### PR TITLE
Feature/issue#138

### DIFF
--- a/back/src/controller/authController.ts
+++ b/back/src/controller/authController.ts
@@ -19,16 +19,16 @@ const authController = {
       : response.redirect(`${process.env.REDIRECT_URL}/signup?client_id=${request.user.providerId}`);
   },
   info: async (request: Request, response: Response, next: NextFunction) => {
-    let data = {};
     if (request.user) {
       const { id, nickname, gender, age } = request.user;
-      data = { id, nickname, gender, age };
+      const data = { id, nickname, gender, age };
+      response.json({
+        result: 'success',
+        message: null,
+        data,
+      });
     }
-    response.json({
-      result: 'success',
-      message: null,
-      data,
-    });
+    response.status(401).end();
   },
   signup: async (request: Request, response: Response, next: NextFunction) => {
     const { clientId: providerId, nickname, gender, age } = request.body;

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,54 +1,38 @@
-import React, { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
+import React from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { GlobalStyle, Reset, theme } from './commons/style';
-import { getUser } from './utils/api/auth';
 import * as ROUTE from './commons/constants/route';
 import * as PAGE from './pages';
-import { loginState, userState } from './recoil/atom';
+import { PrivateRoute } from './components';
+import GlobalStore from './stores';
 
 function App(): JSX.Element {
-  const setIsLoggedIn = useSetRecoilState(loginState);
-  const setUserInfo = useSetRecoilState(userState);
-
-  const getUserInfo = async () => {
-    const user = await getUser();
-    if (Object.keys(user).length !== 0) {
-      setIsLoggedIn(true);
-      setUserInfo(user);
-    } else {
-      setIsLoggedIn(false);
-    }
-  };
-
-  useEffect(() => {
-    getUserInfo();
-  }, []);
-
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <Reset />
-      <Router>
-        <Switch>
-          <Route path={ROUTE.ROOT} component={PAGE.Root} exact />
-          <Route path={ROUTE.MAIN} component={PAGE.Main} exact />
-          <Route path={ROUTE.LOGIN} component={PAGE.Login} />
-          <Route path={ROUTE.SIGNUP} component={PAGE.SignUp} />
-          <Route path={ROUTE.MAKE} component={PAGE.Make} />
-          <Route path={ROUTE.INITIALIZE} component={PAGE.Initialize} />
-          <Route path={ROUTE.WORLDCUP} component={PAGE.Game} />
-          <Route path={ROUTE.MYWORLDCUP} component={PAGE.MyWorldcup} />
-          <Route path={ROUTE.RANKING} component={PAGE.Ranking} />
-          <Route path={ROUTE.MYINFO} component={PAGE.MyInfo} />
-          <Route path={ROUTE.LEAVE} component={PAGE.Leave} />
-          <Route path={ROUTE.EDIT} component={PAGE.Edit} />
-          <Route path={ROUTE.PROFILE} component={PAGE.Profile} />
-          <Route component={PAGE.NotFound} />
-        </Switch>
-      </Router>
-    </ThemeProvider>
+    <GlobalStore>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Reset />
+        <Router>
+          <Switch>
+            <Route path={ROUTE.ROOT} component={PAGE.Root} exact />
+            <Route path={ROUTE.MAIN} component={PAGE.Main} exact />
+            <Route path={ROUTE.LOGIN} component={PAGE.Login} />
+            <Route path={ROUTE.SIGNUP} component={PAGE.SignUp} />
+            <PrivateRoute path={ROUTE.MAKE} component={PAGE.Make} />
+            <PrivateRoute path={ROUTE.INITIALIZE} component={PAGE.Initialize} />
+            <PrivateRoute path={ROUTE.WORLDCUP} component={PAGE.Game} />
+            <PrivateRoute path={ROUTE.MYWORLDCUP} component={PAGE.MyWorldcup} />
+            <Route path={ROUTE.RANKING} component={PAGE.Ranking} />
+            <PrivateRoute path={ROUTE.MYINFO} component={PAGE.MyInfo} />
+            <PrivateRoute path={ROUTE.LEAVE} component={PAGE.Leave} />
+            <PrivateRoute path={ROUTE.EDIT} component={PAGE.Edit} />
+            <PrivateRoute path={ROUTE.PROFILE} component={PAGE.Profile} />
+            <Route component={PAGE.NotFound} />
+          </Switch>
+        </Router>
+      </ThemeProvider>
+    </GlobalStore>
   );
 }
 

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import { GlobalStyle, Reset, theme } from './commons/style';
 import * as ROUTE from './commons/constants/route';
 import * as PAGE from './pages';
-import { PrivateRoute } from './components';
+import { PrivateRoute, PublicRoute } from './components';
 import GlobalStore from './stores';
 
 function App(): JSX.Element {
@@ -16,19 +16,19 @@ function App(): JSX.Element {
         <Router>
           <Switch>
             <Route path={ROUTE.ROOT} component={PAGE.Root} exact />
-            <Route path={ROUTE.MAIN} component={PAGE.Main} exact />
-            <Route path={ROUTE.LOGIN} component={PAGE.Login} />
-            <Route path={ROUTE.SIGNUP} component={PAGE.SignUp} />
+            <PublicRoute path={ROUTE.MAIN} component={PAGE.Main} exact />
+            <PublicRoute path={ROUTE.LOGIN} component={PAGE.Login} />
+            <PublicRoute path={ROUTE.SIGNUP} component={PAGE.SignUp} />
             <PrivateRoute path={ROUTE.MAKE} component={PAGE.Make} />
             <PrivateRoute path={ROUTE.INITIALIZE} component={PAGE.Initialize} />
             <PrivateRoute path={ROUTE.WORLDCUP} component={PAGE.Game} />
             <PrivateRoute path={ROUTE.MYWORLDCUP} component={PAGE.MyWorldcup} />
-            <Route path={ROUTE.RANKING} component={PAGE.Ranking} />
+            <PublicRoute path={ROUTE.RANKING} component={PAGE.Ranking} />
             <PrivateRoute path={ROUTE.MYINFO} component={PAGE.MyInfo} />
             <PrivateRoute path={ROUTE.LEAVE} component={PAGE.Leave} />
             <PrivateRoute path={ROUTE.EDIT} component={PAGE.Edit} />
             <PrivateRoute path={ROUTE.PROFILE} component={PAGE.Profile} />
-            <Route component={PAGE.NotFound} />
+            <PublicRoute component={PAGE.NotFound} />
           </Switch>
         </Router>
       </ThemeProvider>

--- a/front/src/commons/constants/route.ts
+++ b/front/src/commons/constants/route.ts
@@ -11,3 +11,4 @@ export const MYINFO = '/myinfo';
 export const LEAVE = '/leave';
 export const EDIT = '/edit';
 export const PROFILE = '/profile';
+export const IMG_URL_END_POINT = 'https://kr.object.ncloudstorage.com';

--- a/front/src/components/Image/index.tsx
+++ b/front/src/components/Image/index.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { IMG_URL_END_POINT } from '../../commons/constants/route';
+
+interface Props {
+  width: number;
+  height: number;
+  imgKey: string;
+  placeholder: JSX.Element;
+}
+
+function Image({ width, height, imgKey, placeholder }: Props): JSX.Element {
+  const resizedImgURL = `${IMG_URL_END_POINT}/image-w${width}h${height}/${imgKey}.webp`;
+  const originImgURL = `${IMG_URL_END_POINT}/wiziboost-image-raw/${imgKey}`;
+  const [isLoading, setIsLoading] = useState(true);
+  const [imgURL, setImgURL] = useState(resizedImgURL);
+  return (
+    <Container isLoading width={width} height={height}>
+      {isLoading && placeholder}
+      <Img
+        src={imgURL}
+        onLoad={() => setIsLoading(false)}
+        onError={() => setImgURL(originImgURL)}
+        alt={imgURL}
+        isLoading={isLoading}
+        width={width}
+        height={height}
+      />
+    </Container>
+  );
+}
+
+const Container = styled.div<{ isLoading: boolean; width: number; height: number }>`
+  width: ${({ width }) => width}
+  height: ${({ height }) => height};
+  position: relative;
+  border-radius: 13px;
+  div {
+    width: 40px;
+    height: 40px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+  }
+`;
+
+const Img = styled.img<{ isLoading: boolean }>`
+  border-radius: 13px;
+  visibility: ${({ isLoading }) => (isLoading ? 'hidden' : 'visible')};
+`;
+
+export default Image;

--- a/front/src/components/PrivateRoute/index.tsx
+++ b/front/src/components/PrivateRoute/index.tsx
@@ -1,0 +1,46 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import { UserStateContext, UserDispatcherContext } from '../../stores/userStore/index';
+import Loading from '../../pages/Loading';
+import { LOGIN } from '../../commons/constants/route';
+import useApiRequest, { REQUEST } from '../../hooks/useApiRequest';
+import { getUser } from '../../utils/api/auth';
+import { UserInfo } from '../../types/Datas';
+
+interface Props {
+  component: (props: any) => JSX.Element;
+  path?: string;
+}
+
+function PrivateRoute({ component: TargetPage, path }: Props): JSX.Element {
+  const [isLoginChecked, setIsLoginChecked] = useState(false);
+  const { isLoggedIn } = useContext(UserStateContext);
+  const userDispatcher = useContext(UserDispatcherContext);
+
+  const onGetUserSuccess = ({ data: userInfo }: { data: UserInfo }) => {
+    userDispatcher({ type: 'LOGIN', payload: { ...userInfo, isLoggedIn: true } });
+    setIsLoginChecked(true);
+  };
+  const onGetUserFailure = () => {
+    userDispatcher({ type: 'LOGOUT' });
+    setIsLoginChecked(true);
+  };
+  const getUserDispatcher = useApiRequest(getUser, onGetUserSuccess, onGetUserFailure);
+
+  useEffect(() => {
+    getUserDispatcher({ type: REQUEST });
+  }, []);
+
+  return (
+    <Route
+      path={path}
+      render={(props) => {
+        if (!isLoginChecked) return <Loading />;
+        if (!isLoggedIn) return <Redirect to={LOGIN} />;
+        return <TargetPage {...props} />;
+      }}
+    />
+  );
+}
+
+export default PrivateRoute;

--- a/front/src/components/PrivateRoute/index.tsx
+++ b/front/src/components/PrivateRoute/index.tsx
@@ -1,11 +1,9 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { Redirect, Route } from 'react-router-dom';
-import { UserStateContext, UserDispatcherContext } from '../../stores/userStore/index';
+import { UserStateContext } from '../../stores/userStore/index';
 import Loading from '../../pages/Loading';
 import { LOGIN } from '../../commons/constants/route';
-import useApiRequest, { REQUEST } from '../../hooks/useApiRequest';
-import { getUser } from '../../utils/api/auth';
-import { UserInfo } from '../../types/Datas';
+import { useLoginCheck } from '../../hooks';
 
 interface Props {
   component: (props: any) => JSX.Element;
@@ -13,23 +11,8 @@ interface Props {
 }
 
 function PrivateRoute({ component: TargetPage, path }: Props): JSX.Element {
-  const [isLoginChecked, setIsLoginChecked] = useState(false);
+  const isLoginChecked = useLoginCheck();
   const { isLoggedIn } = useContext(UserStateContext);
-  const userDispatcher = useContext(UserDispatcherContext);
-
-  const onGetUserSuccess = ({ data: userInfo }: { data: UserInfo }) => {
-    userDispatcher({ type: 'LOGIN', payload: { ...userInfo, isLoggedIn: true } });
-    setIsLoginChecked(true);
-  };
-  const onGetUserFailure = () => {
-    userDispatcher({ type: 'LOGOUT' });
-    setIsLoginChecked(true);
-  };
-  const getUserDispatcher = useApiRequest(getUser, onGetUserSuccess, onGetUserFailure);
-
-  useEffect(() => {
-    getUserDispatcher({ type: REQUEST });
-  }, []);
 
   return (
     <Route

--- a/front/src/components/PublicRoute/index.tsx
+++ b/front/src/components/PublicRoute/index.tsx
@@ -1,0 +1,45 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { Route } from 'react-router-dom';
+import { UserDispatcherContext } from '../../stores/userStore/index';
+import Loading from '../../pages/Loading';
+import useApiRequest, { REQUEST } from '../../hooks/useApiRequest';
+import { getUser } from '../../utils/api/auth';
+import { UserInfo } from '../../types/Datas';
+
+interface Props {
+  component: (props: any) => JSX.Element;
+  exact?: boolean;
+  path?: string;
+}
+
+function PublicRoute({ component: TargetPage, exact, path }: Props): JSX.Element {
+  const [isLoginChecked, setIsLoginChecked] = useState(false);
+  const userDispatcher = useContext(UserDispatcherContext);
+
+  const onGetUserSuccess = ({ data: userInfo }: { data: UserInfo }) => {
+    userDispatcher({ type: 'LOGIN', payload: { ...userInfo, isLoggedIn: true } });
+    setIsLoginChecked(true);
+  };
+  const onGetUserFailure = () => {
+    userDispatcher({ type: 'LOGOUT' });
+    setIsLoginChecked(true);
+  };
+  const getUserDispatcher = useApiRequest(getUser, onGetUserSuccess, onGetUserFailure);
+
+  useEffect(() => {
+    getUserDispatcher({ type: REQUEST });
+  }, []);
+
+  return (
+    <Route
+      path={path}
+      exact={exact}
+      render={(props) => {
+        if (!isLoginChecked) return <Loading />;
+        return <TargetPage {...props} />;
+      }}
+    />
+  );
+}
+
+export default PublicRoute;

--- a/front/src/components/PublicRoute/index.tsx
+++ b/front/src/components/PublicRoute/index.tsx
@@ -1,10 +1,7 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React from 'react';
 import { Route } from 'react-router-dom';
-import { UserDispatcherContext } from '../../stores/userStore/index';
 import Loading from '../../pages/Loading';
-import useApiRequest, { REQUEST } from '../../hooks/useApiRequest';
-import { getUser } from '../../utils/api/auth';
-import { UserInfo } from '../../types/Datas';
+import { useLoginCheck } from '../../hooks';
 
 interface Props {
   component: (props: any) => JSX.Element;
@@ -13,22 +10,7 @@ interface Props {
 }
 
 function PublicRoute({ component: TargetPage, exact, path }: Props): JSX.Element {
-  const [isLoginChecked, setIsLoginChecked] = useState(false);
-  const userDispatcher = useContext(UserDispatcherContext);
-
-  const onGetUserSuccess = ({ data: userInfo }: { data: UserInfo }) => {
-    userDispatcher({ type: 'LOGIN', payload: { ...userInfo, isLoggedIn: true } });
-    setIsLoginChecked(true);
-  };
-  const onGetUserFailure = () => {
-    userDispatcher({ type: 'LOGOUT' });
-    setIsLoginChecked(true);
-  };
-  const getUserDispatcher = useApiRequest(getUser, onGetUserSuccess, onGetUserFailure);
-
-  useEffect(() => {
-    getUserDispatcher({ type: REQUEST });
-  }, []);
+  const isLoginChecked = useLoginCheck();
 
   return (
     <Route

--- a/front/src/components/index.ts
+++ b/front/src/components/index.ts
@@ -12,3 +12,4 @@ export { default as RankingList } from './RankingList';
 export { default as RankingModal } from './RankingModal';
 export { default as Comment } from './Comment';
 export { default as PrivateRoute } from './PrivateRoute';
+export { default as PublicRoute } from './PublicRoute';

--- a/front/src/components/index.ts
+++ b/front/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as StoreBtns } from './StoreBtns';
 export { default as RankingList } from './RankingList';
 export { default as RankingModal } from './RankingModal';
 export { default as Comment } from './Comment';
+export { default as PrivateRoute } from './PrivateRoute';

--- a/front/src/hooks/index.ts
+++ b/front/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { default as useUploadState } from './useUploadState';
 export { default as useWorldcupForm } from './useWorldcupForm';
 export { default as useInfiniteScroll } from './useInfiniteScroll';
 export { usePaginationSync, usePaginationAsync } from './usePagination';
+export { default as useLoginCheck } from './useLoginCheck';

--- a/front/src/hooks/useLoginCheck.ts
+++ b/front/src/hooks/useLoginCheck.ts
@@ -1,0 +1,28 @@
+import { useEffect, useContext, useState } from 'react';
+import { UserInfo } from '../types/Datas';
+import { UserDispatcherContext } from '../stores/userStore';
+import useApiRequest, { REQUEST } from './useApiRequest';
+import { getUser } from '../utils/api/auth';
+
+const useLoginCheck = (): boolean => {
+  const [isLoginChecked, setIsLoginChecked] = useState(false);
+  const userDispatcher = useContext(UserDispatcherContext);
+
+  const onGetUserSuccess = ({ data: userInfo }: { data: UserInfo }) => {
+    userDispatcher({ type: 'LOGIN', payload: { ...userInfo, isLoggedIn: true } });
+    setIsLoginChecked(true);
+  };
+  const onGetUserFailure = () => {
+    userDispatcher({ type: 'LOGOUT' });
+    setIsLoginChecked(true);
+  };
+  const getUserDispatcher = useApiRequest(getUser, onGetUserSuccess, onGetUserFailure);
+
+  useEffect(() => {
+    getUserDispatcher({ type: REQUEST });
+  }, []);
+
+  return isLoginChecked;
+};
+
+export default useLoginCheck;

--- a/front/src/pages/Leave/index.tsx
+++ b/front/src/pages/Leave/index.tsx
@@ -15,7 +15,7 @@ const Leave = (): JSX.Element => {
   const leaveHandler = useCallback(() => {
     deleteUser(userInfo.id as number);
     setIsLoggedIn(false);
-    setUserInfo({});
+    setUserInfo({ id: -1, nickname: '', gender: -1, age: -1 });
   }, []);
 
   return !isLoggedIn ? (

--- a/front/src/pages/Loading/index.tsx
+++ b/front/src/pages/Loading/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Loading(): JSX.Element {
+  return <div>로딩 중...</div>;
+}
+
+export default Loading;

--- a/front/src/pages/Login/index.tsx
+++ b/front/src/pages/Login/index.tsx
@@ -1,16 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Redirect } from 'react-router';
 import styled from 'styled-components';
-import { useRecoilValue } from 'recoil';
 import { GoMarkGithub } from 'react-icons/go';
 import { SiKakaotalk } from 'react-icons/si';
 import { FcGoogle } from 'react-icons/fc';
-import { loginState } from '../../recoil/atom';
 import SocialLoginButton from '../../components/SocialLoginButton';
 import logo from '../../images/logo.png';
+import { UserStateContext } from '../../stores/userStore';
 
 function Login(): JSX.Element {
-  const isLoggedIn = useRecoilValue(loginState);
+  const { isLoggedIn } = useContext(UserStateContext);
 
   return isLoggedIn ? (
     <Redirect to="/main" />

--- a/front/src/recoil/atom.ts
+++ b/front/src/recoil/atom.ts
@@ -7,5 +7,5 @@ export const loginState = atom({
 
 export const userState = atom({
   key: 'userState',
-  default: {},
+  default: { id: -1, nickname: '', gender: -1, age: -1 },
 });

--- a/front/src/stores/index.tsx
+++ b/front/src/stores/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import UserStore from './userStore';
+
+function GlobalStore({ children }: { children: JSX.Element }): JSX.Element {
+  return <UserStore>{children}</UserStore>;
+}
+
+export default GlobalStore;

--- a/front/src/stores/userStore/index.tsx
+++ b/front/src/stores/userStore/index.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, Dispatch, useReducer } from 'react';
+import userReducer, { defaultUserState } from './reducer';
+import { UserState } from '../../types/States';
+import { UserAction } from '../../types/Actions';
+import Reducer from '../../types/Reducer';
+
+export const UserStateContext = createContext<UserState>(defaultUserState);
+export const UserDispatcherContext = createContext<Dispatch<UserAction>>(() => {});
+
+function UserStore({ children }: { children: JSX.Element }): JSX.Element {
+  const [userState, userDispatcher] = useReducer<Reducer<UserState, UserAction>>(userReducer, defaultUserState);
+
+  return (
+    <UserStateContext.Provider value={userState}>
+      <UserDispatcherContext.Provider value={userDispatcher}>{children}</UserDispatcherContext.Provider>
+    </UserStateContext.Provider>
+  );
+}
+
+export default UserStore;

--- a/front/src/stores/userStore/reducer.ts
+++ b/front/src/stores/userStore/reducer.ts
@@ -1,0 +1,24 @@
+import { UserState } from '../../types/States';
+import { UserAction } from '../../types/Actions';
+
+export const defaultUserState: UserState = {
+  isLoggedIn: false,
+  id: null,
+  nickname: null,
+  gender: null,
+  age: null,
+};
+
+export default function userReducer(state: UserState, action: UserAction): UserState {
+  switch (action.type) {
+    case 'LOGOUT': {
+      return defaultUserState;
+    }
+    case 'LOGIN': {
+      return action.payload;
+    }
+    default: {
+      throw new Error(`Unexpected action type`);
+    }
+  }
+}

--- a/front/src/types/Actions.ts
+++ b/front/src/types/Actions.ts
@@ -1,4 +1,8 @@
+import { UserState } from './States';
+
 export interface FormAction<T> {
   type: keyof T;
   payload: T[keyof T];
 }
+
+export type UserAction = { type: 'LOGOUT' } | { type: 'LOGIN'; payload: UserState };

--- a/front/src/types/Datas.ts
+++ b/front/src/types/Datas.ts
@@ -102,10 +102,10 @@ export interface Candidate {
 }
 
 export interface UserInfo {
-  id?: number;
-  nickname?: string;
-  gender?: number;
-  age?: number;
+  id: number;
+  nickname: string;
+  gender: number;
+  age: number;
 }
 
 export interface Worldcup {

--- a/front/src/types/Reducer.ts
+++ b/front/src/types/Reducer.ts
@@ -1,0 +1,3 @@
+type Reducer<S, A> = (state: S, action: A) => S;
+
+export default Reducer;

--- a/front/src/types/States.ts
+++ b/front/src/types/States.ts
@@ -6,3 +6,11 @@ export interface WorldcupFormState {
   keywords: string[];
   imgInfos: ImgInfo[];
 }
+
+export interface UserState {
+  isLoggedIn: boolean;
+  id: number | null;
+  nickname: string | null;
+  gender: number | null;
+  age: number | null;
+}

--- a/front/src/utils/api/auth.ts
+++ b/front/src/utils/api/auth.ts
@@ -1,17 +1,11 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 interface ServerResponse {
   result: string;
   message: string | null;
 }
 
-export const getUser = async (): Promise<ServerResponse> => {
-  const response = await axios.get('/api/auth/info');
-  const {
-    data: { data: userInfo },
-  } = response;
-  return userInfo;
-};
+export const getUser = (): Promise<AxiosResponse> => axios.get('/api/auth/info');
 
 export const signup = async (
   clientId: string,


### PR DESCRIPTION
- Context Api를 이용하여 유저의 계정 정보를 전역으로 제공해주는 UserStore 컴포넌트 추가
- PrivateRoute, PublicRoute 컴포넌트 추가
- PrivateRoute, PublicRoute 둘 다 로그인 여부 확인 후 유저 정보를 저장 하지만, PrivateRoute는 로그인 안되어있으면 login페이지로 리다이렉트 시킨다는 차이점이 있습니다.
- 원래는 로그인 여부 확인이 getUser API로 받은 응답을 Object.keys에 넣어서 length > 0 일때만 로그인 되어있다고 판단하는 방식이었는 듯 한데, 서버에서 401에러를 주면 로그인이 안된 것으로 판단하도록 변경하였습니다.
- { id: -1, nickname: '', gender: -1, age: -1 } 이 부분은 리코일과 UserStore가 최소한 에러는 안나는 선에서 함께 동작할 수 있도록 임시로 넣어놓은 코드입니다.
- close #139 
- close #138 