### PR TITLE
header props에 직접 searchBar를 넘기는 방식으로 변경

### DIFF
--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -5,20 +5,12 @@ import { useHistory } from 'react-router';
 import '@fontsource/rancho';
 import { FaUserAlt } from 'react-icons/fa';
 import HeaderModal from './HeaderModal';
-import SearchBar from '../SearchBar';
 import { UserStateContext } from '../../stores/userStore';
 
-interface headerProps {
-  type: 'header';
-}
-interface searchHeaderProps {
-  type: 'searchHeader';
-  onSubmit: React.MouseEventHandler<HTMLButtonElement>;
-  onSearchWordChange: React.ChangeEventHandler<HTMLInputElement>;
-  searchWord: string;
+interface Props {
+  searchBar?: JSX.Element;
   onResetData?: () => void;
 }
-type Props = headerProps | searchHeaderProps;
 
 function Header(props: Props): JSX.Element {
   const { isLoggedIn } = useContext(UserStateContext);
@@ -26,13 +18,13 @@ function Header(props: Props): JSX.Element {
   const history = useHistory();
   const url = useMemo(() => history.location.pathname.split('/')[1], []);
   const [modal, setModal] = useState(false);
-  const prop = { ...props };
+  const { searchBar, onResetData } = props;
   const toggleModal = () => {
     setModal(!modal);
   };
   const onMoveMainPage = () => {
-    if (url === 'main' && props.type === 'searchHeader' && props.onResetData) {
-      props.onResetData();
+    if (url === 'main' && onResetData) {
+      onResetData();
     } else history.push('/main');
   };
   return (
@@ -41,29 +33,19 @@ function Header(props: Props): JSX.Element {
       <MainHeader>
         <Logo onClick={onMoveMainPage}>world cup</Logo>
         <RightHeader>
-          {prop.type === 'searchHeader' ? (
-            <SearchBar
-              onSubmit={prop.onSubmit}
-              onSearchWordChange={prop.onSearchWordChange}
-              searchWord={prop.searchWord}
-            />
+          {searchBar || ''}
+          {isLoggedIn ? (
+            <UserIcon onClick={toggleModal} />
           ) : (
-            ''
+            <Link
+              to={{
+                pathname: '/login',
+                state: { from: location.pathname },
+              }}
+            >
+              <Login>로그인</Login>
+            </Link>
           )}
-          <>
-            {isLoggedIn ? (
-              <UserIcon onClick={toggleModal} />
-            ) : (
-              <Link
-                to={{
-                  pathname: '/login',
-                  state: { from: location.pathname },
-                }}
-              >
-                <Login>로그인</Login>
-              </Link>
-            )}
-          </>
           {modal && <HeaderModal open={modal} setModal={setModal} />}
         </RightHeader>
       </MainHeader>

--- a/front/src/pages/Edit/index.tsx
+++ b/front/src/pages/Edit/index.tsx
@@ -79,7 +79,7 @@ function Edit(): JSX.Element {
 
   return (
     <>
-      <Header type="header" />
+      <Header />
       <Content>
         <TabBar currentTab={currentTab} onTabChange={onTabChange} tabTitle={tabTitle} />
         {currentTab === 1 && (

--- a/front/src/pages/Game/index.tsx
+++ b/front/src/pages/Game/index.tsx
@@ -117,7 +117,7 @@ function Worldcup(): JSX.Element {
 
   return !gameInfo?.isCompleted ? (
     <Wrapper>
-      <Header type="header" />
+      <Header />
       <InfoContainer>
         <Title>
           {gameInfo?.title} {gameInfo?.currentRound}/{gameInfo?.round}

--- a/front/src/pages/Gameover/index.tsx
+++ b/front/src/pages/Gameover/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 function Gameover({ winCandidate, title, worldcupId }: Props): JSX.Element {
   return (
     <Wrapper>
-      <Header type="header" />
+      <Header />
       <Container>
         <img src={trophyImg} alt="trophy" />
         <Title>{title || ''} 우승!</Title>

--- a/front/src/pages/Initialize/index.tsx
+++ b/front/src/pages/Initialize/index.tsx
@@ -69,7 +69,7 @@ function Initialize(): JSX.Element {
     <Redirect to={WORLDCUP} />
   ) : (
     <>
-      <Header type="header" />
+      <Header />
       <Container>
         <InfoContainer>
           <img src={logo} alt="logo" width="220px" height="200px" />

--- a/front/src/pages/Leave/index.tsx
+++ b/front/src/pages/Leave/index.tsx
@@ -16,7 +16,7 @@ const Leave = (): JSX.Element => {
 
   return (
     <>
-      <Header type="header" />
+      <Header />
       <Container>
         <img src={logo} alt="logo" width="220px" height="220px" />
         <Title>탈퇴하시겠습니까?</Title>

--- a/front/src/pages/Main/index.tsx
+++ b/front/src/pages/Main/index.tsx
@@ -5,6 +5,7 @@ import { useInfiniteScroll } from '../../hooks';
 import { getWorldcupList } from '../../apis/worldcups';
 import { Worldcup } from '../../types/Datas';
 import { FETCH_WORLDCUPS_LIMIT } from '../../constants/number';
+import { SearchBar } from '../../components';
 
 function Main(): JSX.Element {
   const [searchWord, setSearchWord] = useState('');
@@ -45,10 +46,7 @@ function Main(): JSX.Element {
   return (
     <Wrapper>
       <Header
-        type="searchHeader"
-        onSubmit={onSubmit}
-        onSearchWordChange={onSearchWordChange}
-        searchWord={inputWord}
+        searchBar={<SearchBar onSubmit={onSubmit} onSearchWordChange={onSearchWordChange} searchWord={inputWord} />}
         onResetData={onResetData}
       />
       <Keywords onClickTag={onClickTag} selectedTag={selectedTag} />

--- a/front/src/pages/Make/index.tsx
+++ b/front/src/pages/Make/index.tsx
@@ -24,7 +24,7 @@ function Make(): JSX.Element {
 
   return (
     <>
-      <Header type="header" />
+      <Header />
       <Content>
         <TabBar tabTitle={tabTitle} currentTab={currentTab} onTabChange={onTabChange} />
         {currentTab === 1 && (

--- a/front/src/pages/MyInfo/index.tsx
+++ b/front/src/pages/MyInfo/index.tsx
@@ -8,7 +8,7 @@ import { PROFILE, LEAVE } from '../../constants/route';
 const MyInfo = (): JSX.Element => {
   return (
     <>
-      <Header type="header" />
+      <Header />
       <Container>
         <img src={logo} alt="logo" width="220px" height="220px" />
         <Title>내 정보</Title>

--- a/front/src/pages/MyWorldcup/index.tsx
+++ b/front/src/pages/MyWorldcup/index.tsx
@@ -16,7 +16,7 @@ const MyWorldcup = (): JSX.Element => {
 
   return (
     <>
-      <Header type="header" />
+      <Header />
       <WorldcupList
         type="myWorldcup"
         worldcups={worldcups}

--- a/front/src/pages/NotFound/index.tsx
+++ b/front/src/pages/NotFound/index.tsx
@@ -9,7 +9,7 @@ import rightLogo from '../../images/404logo_2.png';
 const NotFound = (): JSX.Element => {
   return (
     <Container>
-      <Header type="header" />
+      <Header />
       <Content>
         <h1>
           <LeftLogo src={leftLogo} alt="404_1" />

--- a/front/src/pages/Profile/index.tsx
+++ b/front/src/pages/Profile/index.tsx
@@ -6,7 +6,7 @@ import logo from '../../images/logo.png';
 const Profile = (): JSX.Element => {
   return (
     <>
-      <Header type="header" />
+      <Header />
       <Container>
         <img src={logo} alt="logo" width="220px" height="220px" />
         <Title>내 정보 수정하기</Title>

--- a/front/src/pages/Ranking/index.tsx
+++ b/front/src/pages/Ranking/index.tsx
@@ -9,7 +9,7 @@ function Ranking(): JSX.Element {
 
   return (
     <Wrapper>
-      <Header type="header" />
+      <Header />
       <RankingContent>
         <RankingList worldcupId={worldcupId} />
       </RankingContent>


### PR DESCRIPTION
## 구현내용
1. header props에 searchBar tag를 직접 넘기는 방식으로 리팩터링

## 질문사항
1. 사실 기존 방법도 꽤나 훌륭한 방법이라는 생각을 하게됨
2. 직접 컴포넌트 넘기는 것까진 괜찮았는데 리뷰할때 Main page에서 header사용하는 부분 좀 봐주길 바람

## 관련이슈
#167 