### PR TITLE
메인페이지 검색, 태그 필터링에 url 적용

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -16,7 +16,7 @@ function App(): JSX.Element {
         <Router>
           <Switch>
             <Route path={ROUTE.ROOT} component={PAGE.Root} exact />
-            <PublicRoute path={ROUTE.MAIN} component={PAGE.Main} exact />
+            <PublicRoute path={ROUTE.MAIN} component={PAGE.Main} />
             <PublicRoute path={ROUTE.LOGIN} component={PAGE.Login} />
             <PublicRoute path={ROUTE.SIGNUP} component={PAGE.SignUp} />
             <PrivateRoute path={ROUTE.MAKE} component={PAGE.Make} />

--- a/front/src/components/Header/index.tsx
+++ b/front/src/components/Header/index.tsx
@@ -1,37 +1,29 @@
-import React, { useState, useContext, useMemo } from 'react';
+import React, { useState, useContext } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { useHistory } from 'react-router';
 import '@fontsource/rancho';
 import { FaUserAlt } from 'react-icons/fa';
 import HeaderModal from './HeaderModal';
 import { UserStateContext } from '../../stores/userStore';
-import { MAIN } from '../../constants/route';
 
 interface Props {
   children?: React.ReactNode;
-  onResetData?: () => void;
 }
 
-function Header({ children, onResetData }: Props): JSX.Element {
+function Header({ children }: Props): JSX.Element {
   const { isLoggedIn } = useContext(UserStateContext);
   const location = useLocation();
-  const history = useHistory();
-  const url = useMemo(() => history.location.pathname.split('/')[1], []);
   const [modal, setModal] = useState(false);
   const toggleModal = () => {
     setModal(!modal);
-  };
-  const onMoveMainPage = () => {
-    if (url === 'main' && onResetData) {
-      onResetData();
-    } else history.push(MAIN);
   };
   return (
     <>
       {modal && <Overlay onClick={() => setModal(false)} />}
       <MainHeader>
-        <Logo onClick={onMoveMainPage}>world cup</Logo>
+        <Link to="/">
+          <Logo>world cup</Logo>
+        </Link>
         <RightHeader>
           {children}
           {isLoggedIn ? (

--- a/front/src/pages/Main/index.tsx
+++ b/front/src/pages/Main/index.tsx
@@ -11,14 +11,20 @@ import WorldCupItem from '../../components/WorldCupItem';
 function Main(): JSX.Element {
   const location = useLocation();
   const history = useHistory();
-  const searchWord = useMemo(() => (location.search.split('=')[1] ? location.search.split('=')[1] : ''), [location]);
-  const keyword = useMemo(
-    () =>
-      location.pathname.split('/')[2] !== 'search' && location.pathname.split('/')[2]
-        ? location.pathname.split('/')[2]
-        : '',
-    [location],
-  );
+  const searchWord = useMemo(() => {
+    const params = new URLSearchParams(location.search).get('title');
+    if (params) {
+      return params;
+    }
+    return '';
+  }, [location]);
+  const keyword = useMemo(() => {
+    const path = location.pathname.split('/')[2];
+    if (path !== 'search' && path) {
+      return path;
+    }
+    return '';
+  }, [location]);
   const [inputWord, setInputWord] = useState('');
   const {
     items: worldcups,


### PR DESCRIPTION
<img width="937" alt="스크린샷 2021-11-30 오후 4 39 24" src="https://user-images.githubusercontent.com/40332307/144005534-6f819688-1b1b-4164-a48c-b5bd5a0e7f4d.png">

<img width="940" alt="스크린샷 2021-11-30 오후 4 39 14" src="https://user-images.githubusercontent.com/40332307/144005561-24f3f2af-cc44-40cb-9cfd-b7f33ef46eb6.png">

- 검색바를 이용하는 것과, keyword는 다르게 구성함 
=> 둘다.. 검색이긴한데, tag는 뭔가 그 네이버처럼 섹션을 나누고 싶어서 url을 path로 했는데, 다른 의견이 있으면 수정할게!!

- url 에서 keyword, search 가져오는 부분은 정규표현식을 이용하는게 더 나을까?

- #196 