### PR TITLE
자신이 만든 월드컵이 아닌경우 수정&삭제 못하도록 수정

### DIFF
--- a/back/src/controller/worldcupController.ts
+++ b/back/src/controller/worldcupController.ts
@@ -25,15 +25,26 @@ const worldcupController = {
   },
 
   getMetadata: async (request: Request, response: Response, next: NextFunction) => {
+    if (!request.user) {
+      return response.status(401).json(failed('Unauthorized'));
+    }
     const {
-      params: { id },
+      params: { id: worldcupId },
+      user: { id: userId },
       query: { metaonly, searchWord },
     } = request;
-    if (metaonly) {
-      const worldcupMetadata = await worldcupService.getMetaData(Number(id), String(searchWord));
-      return response.json(succeed(worldcupMetadata));
+    try {
+      if (metaonly) {
+        const worldcupMetadata = await worldcupService.getMetaData(
+          Number(worldcupId),
+          Number(userId),
+          String(searchWord),
+        );
+        return response.json(succeed(worldcupMetadata));
+      }
+    } catch (e) {
+      response.status(400).json(failed(e.message));
     }
-    response.status(400).json(failed('cannot get worldcup metadata'));
   },
 
   save: async (request: Request, response: Response, next: NextFunction) => {

--- a/back/src/controller/worldcupController.ts
+++ b/back/src/controller/worldcupController.ts
@@ -52,12 +52,16 @@ const worldcupController = {
   },
 
   delete: async (request: Request, response: Response, next: NextFunction) => {
-    const { id } = request.params;
+    if (!request.user) return response.status(401).json(failed('not authorized'));
+    const {
+      params: { id: worldcupId },
+      user: { id: userId },
+    } = request;
     try {
-      await worldcupService.removeById(Number(id));
+      await worldcupService.removeById(Number(worldcupId), Number(userId));
       response.json(succeed(null));
     } catch (e) {
-      response.status(400).json(failed('cannot delete worldcup'));
+      response.status(400).json(failed(e.message));
     }
   },
 

--- a/back/src/services/worldcupService.ts
+++ b/back/src/services/worldcupService.ts
@@ -107,12 +107,17 @@ export const getMetaData = async (id: number, searchWord?: String) => {
   return { totalCnt, title, description, keywords };
 };
 
-export const removeById = async (id: number) => {
-  const worldcup = getRepository(Worldcup);
-  const { keywords } = await worldcup.findOne(id, { relations: ['keywords'] });
-  keywords.map((keyword) => {
+export const removeById = async (worldcupId: number, userId: number) => {
+  const worldcupRepository = getRepository(Worldcup);
+  const worldcup = await worldcupRepository.findOne(worldcupId, { relations: ['keywords', 'user'] });
+
+  if (worldcup.user.id !== userId) {
+    throw new Error('삭제 권한이 없습니다.');
+  }
+
+  worldcup.keywords.map((keyword) => {
     keyword.cnt--;
     keywordService.save(keyword);
   });
-  worldcup.delete(id);
+  await worldcupRepository.delete(worldcupId);
 };

--- a/back/src/services/worldcupService.ts
+++ b/back/src/services/worldcupService.ts
@@ -98,12 +98,11 @@ export const patchDesc = async (id: number, desc: string) => {
 
 export const getMetaData = async (id: number, searchWord?: String) => {
   const worldcupRepository: Repository<Worldcup> = getRepository(Worldcup);
-  const [worldcup, totalCnt, worldcupKeyword] = await Promise.all([
-    worldcupRepository.findOne(id),
-    searchWord ? candidateService.getTotalCountBySearchhWord(id, searchWord) : candidateService.getTotalCount(id),
+  const [worldcup, totalCnt] = await Promise.all([
     worldcupRepository.findOne(id, { relations: ['keywords'] }),
+    searchWord ? candidateService.getTotalCountBySearchhWord(id, searchWord) : candidateService.getTotalCount(id),
   ]);
-  const keywords = worldcupKeyword.keywords.map((keyword) => keyword.name);
+  const keywords = worldcup.keywords.map((keyword) => keyword.name);
   const { title, description } = worldcup;
   return { totalCnt, title, description, keywords };
 };

--- a/back/src/services/worldcupService.ts
+++ b/back/src/services/worldcupService.ts
@@ -96,12 +96,19 @@ export const patchDesc = async (id: number, desc: string) => {
     .execute();
 };
 
-export const getMetaData = async (id: number, searchWord?: String) => {
+export const getMetaData = async (worldcupId: number, userId: number, searchWord?: String) => {
   const worldcupRepository: Repository<Worldcup> = getRepository(Worldcup);
   const [worldcup, totalCnt] = await Promise.all([
-    worldcupRepository.findOne(id, { relations: ['keywords'] }),
-    searchWord ? candidateService.getTotalCountBySearchhWord(id, searchWord) : candidateService.getTotalCount(id),
+    worldcupRepository.findOne(worldcupId, { relations: ['keywords', 'user'] }),
+    searchWord
+      ? candidateService.getTotalCountBySearchhWord(worldcupId, searchWord)
+      : candidateService.getTotalCount(worldcupId),
   ]);
+
+  if (worldcup.user.id !== userId) {
+    throw new Error('수정 권한이 없습니다.');
+  }
+
   const keywords = worldcup.keywords.map((keyword) => keyword.name);
   const { title, description } = worldcup;
   return { totalCnt, title, description, keywords };

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -22,7 +22,7 @@ function App(): JSX.Element {
               <PublicRoute path={ROUTE.MAIN} component={getLazyLoadComponent('Main')} exact />
               <PublicRoute path="/search" component={getLazyLoadComponent('Main')} />
               <PublicRoute path={ROUTE.LOGIN} component={getLazyLoadComponent('Login')} />
-              <PublicRoute path={ROUTE.SIGNUP} component={getLazyLoadComponent('SiguUp')} />
+              <PublicRoute path={ROUTE.SIGNUP} component={getLazyLoadComponent('SignUp')} />
               <PrivateRoute path={ROUTE.MAKE} component={getLazyLoadComponent('Make')} />
               <PrivateRoute path={ROUTE.INITIALIZE} component={getLazyLoadComponent('Initialize')} />
               <PrivateRoute path={ROUTE.WORLDCUP} component={getLazyLoadComponent('Game')} />

--- a/front/src/pages/Edit/index.tsx
+++ b/front/src/pages/Edit/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '../../components/Header';
 import MakeWorldcupForm from '../../components/MakeWorldcupForm';
@@ -20,6 +20,7 @@ import { MAIN } from '../../constants/route';
 function Edit(): JSX.Element {
   const worldcupId = useMemo(() => Number(window.location.pathname.split('/')[2]), [window.location]);
   const tabTitle = ['1. 기본정보 수정 / 이미지 업로드', '2. 이미지 이름 수정 / 삭제'];
+  const history = useHistory();
   const [addedImgs, addedImgsDispatcher] = useImgInfos();
   const [candidates, candidatesDispatcher] = useImgInfos();
   const [totalCnt, setTotalCnt] = useState(0);
@@ -40,7 +41,16 @@ function Edit(): JSX.Element {
     worldcupFormDispatcher({ type: 'ADD_KEYWORDS', payload: keywords });
     setTotalCnt(totalCnt);
   };
-  const getMetadataDispatcher = useApiRequest<WorldcupMetaData>(getWorldcupMetadata, onGetMetadataSuccess);
+
+  const onGetMetadataFailed = () => {
+    history.push(MAIN);
+  };
+
+  const getMetadataDispatcher = useApiRequest<WorldcupMetaData>(
+    getWorldcupMetadata,
+    onGetMetadataSuccess,
+    onGetMetadataFailed,
+  );
 
   const createCandidatesDispatcher = useApiRequest(createCandidates);
 

--- a/front/src/pages/Edit/index.tsx
+++ b/front/src/pages/Edit/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '../../components/Header';
 import MakeWorldcupForm from '../../components/MakeWorldcupForm';
@@ -20,6 +20,7 @@ import { MAIN } from '../../constants/route';
 function Edit(): JSX.Element {
   const worldcupId = useMemo(() => Number(window.location.pathname.split('/')[2]), [window.location]);
   const tabTitles = useMemo(() => ['1. 기본정보 수정 / 이미지 업로드', '2. 이미지 이름 수정 / 삭제'], []);
+  const history = useHistory();
   const [addedImgs, addedImgsDispatcher] = useImgInfos();
   const [candidates, candidatesDispatcher] = useImgInfos();
   const [totalCnt, setTotalCnt] = useState(0);
@@ -40,7 +41,16 @@ function Edit(): JSX.Element {
     worldcupFormDispatcher({ type: 'ADD_KEYWORDS', payload: keywords });
     setTotalCnt(totalCnt);
   };
-  const getMetadataDispatcher = useApiRequest<WorldcupMetaData>(getWorldcupMetadata, onGetMetadataSuccess);
+
+  const onGetMetadataFailed = () => {
+    history.push(MAIN);
+  };
+
+  const getMetadataDispatcher = useApiRequest<WorldcupMetaData>(
+    getWorldcupMetadata,
+    onGetMetadataSuccess,
+    onGetMetadataFailed,
+  );
 
   const createCandidatesDispatcher = useApiRequest(createCandidates);
 


### PR DESCRIPTION
## 구현내용
1. 타인이 만든 월드컵을 삭제할 수 없다.
2. 로그인 정보가 없으면 삭제 수정 불가능
3. 타인의 월드컵을 수정할 수 없도록 변경

## 리팩터링
1. back쪽에서 불필요한 함수 제거